### PR TITLE
Discord通知のバグ修正

### DIFF
--- a/app/controllers/goals/comments_controller.rb
+++ b/app/controllers/goals/comments_controller.rb
@@ -22,7 +22,7 @@ class Goals::CommentsController < ApplicationController
 
     if comment.mention_other_than_commentable_user? && !current_user?(@goal.user)
       comment.notifications.create!(user: @goal.user, content: "#{@goal.formatted_title}に#{current_user.name}さんからコメントがありました")
-      comment.send_message_to_discord(:comment)
+      comment.send_message_to_discord(send_user: @goal.user, notification_type: :comment)
     end
 
     respond_to do |format|

--- a/app/controllers/tasks/comments_controller.rb
+++ b/app/controllers/tasks/comments_controller.rb
@@ -22,7 +22,7 @@ class Tasks::CommentsController < ApplicationController
     comment.timelines.create!(user: current_user, content: "#{current_user.name}さんが#{@task.formatted_content}にコメントしました")
     if comment.mention_other_than_commentable_user? && !current_user?(@task.user)
       comment.notifications.create!(user: @task.user, content: "#{@task.formatted_content}に#{current_user.name}さんからコメントがありました")
-      comment.send_message_to_discord(:comment)
+      comment.send_message_to_discord(send_user: @task.user, notification_type: :comment)
     end
 
     respond_to do |format|

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -33,7 +33,7 @@ class Comment < ApplicationRecord
       next unless mentioned_user
 
       notifications.create!(user: mentioned_user, content: "コメントで#{user.name}さんからメンションされました")
-      send_message_to_discord(:mention)
+      send_message_to_discord(send_user: mentioned_user, notification_type: :mention)
     end
   end
 
@@ -46,7 +46,7 @@ class Comment < ApplicationRecord
     goal? ? goal_comments_url(commentable) : task_comments_url(commentable)
   end
 
-  def send_message_to_discord(notification_type)
+  def send_message_to_discord(send_user:, notification_type:)
     notification_type_word =
       case notification_type
       when :comment
@@ -58,7 +58,7 @@ class Comment < ApplicationRecord
     Discordrb::API::Channel.create_message(
       "Bot #{ENV.fetch('DISCORD_BOT_TOKEN', nil)}",
       ENV.fetch('DISCORD_CHANNEL_ID', nil),
-      "<@#{commentable.user.uid}>さん\n\n#{goal? ? commentable.formatted_title : commentable.formatted_content}に#{user.name}さんから
+      "<@#{send_user.uid}>さん\n\n#{goal? ? commentable.formatted_title : commentable.formatted_content}に#{user.name}さんから
       #{notification_type_word}がありました\n\nコメント本文\n「#{formatted_content}」\n\n[詳細はこちら](#{comment_url})".delete(' ')
     )
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -111,13 +111,14 @@ RSpec.describe Comment do
     end
 
     let(:comment) { create(:comment) }
+    let(:user) { create(:user) }
 
     it 'Discordに通知ができる' do
-      expect(comment.send_message_to_discord(:comment)).to eq 'Discordに通知しました'
+      expect(comment.send_message_to_discord(send_user: user, notification_type: :comment)).to eq 'Discordに通知しました'
       expect(Discordrb::API::Channel).to have_received(:create_message).once.with(
         "Bot #{ENV.fetch('DISCORD_BOT_TOKEN', nil)}",
         ENV.fetch('DISCORD_CHANNEL_ID', nil),
-        "<@#{comment.commentable.user.uid}>さん\n\n#{comment.commentable.formatted_title}に#{comment.user.name}さんから
+        "<@#{user.uid}>さん\n\n#{comment.commentable.formatted_title}に#{comment.user.name}さんから
         コメントがありました\n\nコメント本文\n「#{comment.formatted_content}」\n\n[詳細はこちら](#{comment.comment_url})".delete(' ')
       )
     end


### PR DESCRIPTION
## issue

- #108 

## やったこと
- Discord通知のバグを修正しました
- 具体的には、Discordで通知するときに、通知対象を指定するようにしました

## やらないこと
なし

## その他
なし